### PR TITLE
Message metadata in Bundle and "bundle_dict"; concurrent async generation of outputs

### DIFF
--- a/automated_llm_eval/policy_helping_functions.py
+++ b/automated_llm_eval/policy_helping_functions.py
@@ -1,63 +1,82 @@
-import pandas as pd
-from automated_llm_eval.prompts import *
 import csv
 
+import pandas as pd
+
+from automated_llm_eval.prompts import *
+
+
 def get_mode_score_compare():
-    df = pd.read_csv('scored_examples/dataset_231103.csv')
+    df = pd.read_csv("scored_examples/dataset_231103.csv")
     # Calculate the mode of 'q2' for each 'idx' group
-    mode_per_idx = df.groupby('idx')['q2'].apply(lambda x: x.mode().iloc[0] if not x.mode().empty else None)
+    mode_per_idx = df.groupby("idx")["q2"].apply(
+        lambda x: x.mode().iloc[0] if not x.mode().empty else None
+    )
     # Create a dictionary mapping 'idx' to the mode of 'q2'
     idx_to_mode = mode_per_idx.to_dict()
     return idx_to_mode
 
+
 def get_data_split(compare=True, compare_type="iii"):
-    train_data= {}
+    train_data = {}
     test_data = {}
     if compare:
-        desired_columns = ["dataset", "idx", "q1", "q2", "q3", "q4", "inputs", "output", "target", "prompt"]
-        with open('scored_examples/dataset_231103.csv', 'r') as file:
-        # Parse the JSON data and store it as a dictionary
+        desired_columns = [
+            "dataset",
+            "idx",
+            "q1",
+            "q2",
+            "q3",
+            "q4",
+            "inputs",
+            "output",
+            "target",
+            "prompt",
+        ]
+        with open("scored_examples/dataset_231103.csv", "r") as file:
+            # Parse the JSON data and store it as a dictionary
             csv_reader = csv.DictReader(file)
             # Iterate through each row in the CSV
             for line_number, row in enumerate(csv_reader, start=1):
-                result={}
-                if type(row) == list or row["dataset"]!=compare_type:
+                result = {}
+                if type(row) == list or row["dataset"] != compare_type:
                     continue
                 for col in desired_columns:
-                    result[col]=row[col]
-                    if line_number%5==0:
-                        test_data[line_number]=result
+                    result[col] = row[col]
+                    if line_number % 5 == 0:
+                        test_data[line_number] = result
                     else:
                         train_data[line_number] = result
-                
+
     else:
-        with open('scored_examples/harm_QA.csv', 'r') as file:
+        with open("scored_examples/harm_QA.csv", "r") as file:
             desired_columns = ["LLM-Generated Statements", "Human Label (Dev)"]
             csv_reader = csv.DictReader(file)
             # Iterate through each row in the CSV
             for line_number, row in enumerate(csv_reader, start=1):
-                result={}
+                result = {}
                 for col in desired_columns:
-                    result[col]=row[col]
-                    if line_number%5==0:
-                        test_data[line_number]=result
+                    result[col] = row[col]
+                    if line_number % 5 == 0:
+                        test_data[line_number] = result
                     else:
                         train_data[line_number] = result
     return train_data, test_data
 
+
 def get_policy_file(compare=True):
     if compare:
-        with open('policies/summary_compare_correctness_policy.txt', 'r') as file:
+        with open("policies/summary_compare_correctness_policy.txt", "r") as file:
             current_policy = file.read()
     else:
-        with open('policies/safety_policy.txt', 'r') as file:
+        with open("policies/safety_policy.txt", "r") as file:
             current_policy = file.read()
     return current_policy
 
+
 def save_as_csv(data_dict, csv_file):
-    with open(csv_file, 'w', newline='') as file:
+    with open(csv_file, "w", newline="") as file:
         writer = csv.DictWriter(file, fieldnames=data_dict.keys())
         writer.writeheader()
-        
+
         for row in zip(*data_dict.values()):
             writer.writerow(dict(zip(data_dict.keys(), row)))

--- a/automated_llm_eval/policy_tuning.py
+++ b/automated_llm_eval/policy_tuning.py
@@ -1,85 +1,221 @@
-import pandas as pd
-from tqdm import tqdm
-from automated_llm_eval.prompts import *
-from automated_llm_eval.create_chat_completion import create_chat_completion
-from automated_llm_eval.chat_model import ChatModel
-from automated_llm_eval.utils import ProgressBar
 import random
-from automated_llm_eval.policy_helping_functions import *
+
+from automated_llm_eval.chat_model import ChatModel, Message
+from automated_llm_eval.policy_helping_functions import (
+    get_data_split,
+    get_mode_score_compare,
+    get_policy_file,
+    save_as_csv,
+)
+from automated_llm_eval.prompts import (
+    COMPARE_AGENT_PROMPT,
+    GPT_SYSTEM_PROMPT,
+    POLICY_MUTATE_PROMPT_TEMPLATE,
+    QA_AGENT_PROMPT,
+    SCORE_RETRIEVAL_PROMPT,
+    prompt_improvement_character_prompt,
+    score_retrieval_character_prompt,
+)
+from automated_llm_eval.utils import sidethread_event_loop_async_runner
+
 
 def create_agent_response(current_policy, source_text, compare, statement_a=None, statement_b=None):
-    gpt_system_prompt = "You are an expert AI agent, possessing an in-depth knowledge and expertise within the healthcare and medical domain."
-    model = ChatModel(model="gpt-3.5-turbo-1106", temperature=0.5, top_p=0.5, max_tokens=700, seed=42)
+    gpt_system_prompt = GPT_SYSTEM_PROMPT
+    model = ChatModel(
+        model="gpt-3.5-turbo-1106", temperature=0.5, top_p=0.5, max_tokens=700, seed=42
+    )
     if compare:
-        compare_gpt_prompt = COMPARE_AGENT_PROMPT.format(source = source_text, current_policy=current_policy, summary_a = statement_a, summary_b = statement_b)
-        gpt_response = model.create_chat_completion(gpt_system_prompt, compare_gpt_prompt, output_format='simple')
+        compare_gpt_prompt = COMPARE_AGENT_PROMPT.format(
+            source=source_text,
+            current_policy=current_policy,
+            summary_a=statement_a,
+            summary_b=statement_b,
+        )
+        gpt_response = model.create_chat_completion(
+            gpt_system_prompt, compare_gpt_prompt, output_format="simple"
+        )
     else:
-        safety_gpt_prompt = QA_AGENT_PROMPT.format(statement=source_text, current_policy=current_policy)
-        gpt_response = model.create_chat_completion(gpt_system_prompt, safety_gpt_prompt, output_format='simple')
-    return gpt_response    
+        safety_gpt_prompt = QA_AGENT_PROMPT.format(
+            statement=source_text, current_policy=current_policy
+        )
+        gpt_response = model.create_chat_completion(
+            gpt_system_prompt, safety_gpt_prompt, output_format="simple"
+        )
+    return gpt_response
+
+
+def select_batch(dataset: dict, batch_size: int, seed: int = 42) -> list:
+    examples = list(dataset.values())
+    examples = random.Random(seed).shuffle(examples)
+    batch = examples[: len(examples) // batch_size]
+    return batch
+
+
+def construct_message(example: dict, current_policy: str, compare: bool):
+    # Form Agent Response Score & Metadata
+    if compare:
+        idx_to_mode = get_mode_score_compare()
+        statement = example["inputs"]
+        human_response = example["target"]
+        agent_response = example["output"]
+        agent_response_score = create_agent_response(
+            current_policy, statement, compare, human_response, agent_response
+        )
+        metadata = {
+            "human_score": idx_to_mode[int(example["idx"])],
+            "statement": statement,
+            "human_response": human_response,
+            "agent_response": agent_response,
+            "agent_response_score": agent_response_score,
+        }
+
+    else:
+        agent_response_score = create_agent_response(current_policy, statement, compare)
+        metadata = {
+            "human_score": int(example["Human Label (Dev)"]),
+            "statement": example["LLM-Generated Statements"],
+            "agent_response_score": agent_response_score,
+        }
+
+    # Create Messages
+    system_message = score_retrieval_character_prompt
+    user_message = SCORE_RETRIEVAL_PROMPT.format(response=agent_response_score)
+    messages = [
+        {"role": "system", "content": system_message},
+        {"role": "user", "content": user_message},
+    ]
+
+    return Message(messages=messages, metadata=metadata)
+
+
+def generate_for_dataset(
+    dataset: dict,
+    batch_size: int,
+    compare: bool,
+    model: str = "gpt-3.5-turbo-1106",
+    temperature: float = 0.1,
+    top_p: float = 0.5,
+    max_tokens: int = 700,
+    seed: int = 42,
+    num_concurrent: int = 5,
+    output_format: str = "bundle",
+):
+    "Selects batch, formats messages, asynchronously makes LLM calls"
+    # Select Batch
+    batch = select_batch(dataset=dataset, batch_size=batch_size, compare=compare)
+    # Create Message Prompts + Metadata
+    msg_list = []
+    for example in batch:
+        msg = construct_message(example=example, compare=compare)
+        msg_list += [msg]
+    # Create ChatModel
+    model = ChatModel(
+        model=model, temperature=temperature, top_p=top_p, max_tokens=max_tokens, seed=seed
+    )
+    # Async ChatCompletion on another thread
+    result = sidethread_event_loop_async_runner(
+        async_function=model.async_chat_completions(
+            messages_list=msg_list, num_concurrent=num_concurrent, output_format=output_format
+        )
+    )
+    return result
+
 
 def check_policy_accuracy(dataset, current_policy, batchsize, compare):
     incorrect_labelled = []
-    correct_labelled=[]
+    correct_labelled = []
     if compare:
         idx_to_mode = get_mode_score_compare()
-    k=0
-    shuffled_data= list(dataset.values())
+    k = 0
+    shuffled_data = list(dataset.values())
     random.shuffle(shuffled_data)
-    for example in shuffled_data[:len(shuffled_data)//batchsize]:
-        print('WE ARE ON THE ', k, 'th example')
-        if compare:    
+    for example in shuffled_data[: len(shuffled_data) // batchsize]:
+        print("WE ARE ON THE ", k, "th example")
+        if compare:
             human_score = idx_to_mode[int(example["idx"])]
             statement = example["inputs"]
             agent_response = example["output"]
             human_response = example["target"]
-            agent_response_score = create_agent_response(current_policy, statement, compare, human_response, agent_response)
+            agent_response_score = create_agent_response(
+                current_policy, statement, compare, human_response, agent_response
+            )
         else:
             statement = example["LLM-Generated Statements"]
             human_score = int(example["Human Label (Dev)"])
             agent_response_score = create_agent_response(current_policy, statement, compare)
 
-        SCORE_RETRIEVAL = SCORE_RETRIEVAL_PROMPT.format(response=agent_response_score) 
-        model_score = ChatModel(model="gpt-3.5-turbo-1106", temperature=.1, top_p=0.5, max_tokens=700, seed=42)
-        response_score_string = model_score.create_chat_completion(score_retrieval_character_prompt, SCORE_RETRIEVAL, output_format='simple')
+        SCORE_RETRIEVAL = SCORE_RETRIEVAL_PROMPT.format(response=agent_response_score)
+        model_score = ChatModel(
+            model="gpt-3.5-turbo-1106", temperature=0.1, top_p=0.5, max_tokens=700, seed=42
+        )
+        response_score_string = model_score.create_chat_completion(
+            score_retrieval_character_prompt, SCORE_RETRIEVAL, output_format="simple"
+        )
         try:
             response_score = int(response_score_string)
             if response_score != human_score:
-                print('incorrect result from agent')
-                statement_analysis = "The following statement: " + statement + " was given a score of: " + str(response_score) +" by the agent, but the correct score should have been: " + str(human_score) + ". The agent's reasoning for this score is as follows: " + agent_response_score
+                print("incorrect result from agent")
+                statement_analysis = (
+                    "The following statement: "
+                    + statement
+                    + " was given a score of: "
+                    + str(response_score)
+                    + " by the agent, but the correct score should have been: "
+                    + str(human_score)
+                    + ". The agent's reasoning for this score is as follows: "
+                    + agent_response_score
+                )
                 incorrect_labelled.append(statement_analysis)
             else:
                 correct_labelled.append(statement)
-        except:
-            print('RESPONSE SCORE STRING ERROR:', response_score_string)
-        k+=1
-    score = len(correct_labelled)/ (len(correct_labelled)+len(incorrect_labelled)) or 0
+        except Exception:
+            print("RESPONSE SCORE STRING ERROR:", response_score_string)
+        k += 1
+    score = len(correct_labelled) / (len(correct_labelled) + len(incorrect_labelled)) or 0
     return current_policy, score, correct_labelled, incorrect_labelled
-        
-def policy_tuning(output, compare, batch_size, compare_type='iii'):
+
+
+def policy_tuning(output, compare, batch_size, compare_type="iii"):
     score = 0.0
     train_data, test_data = get_data_split(compare, compare_type)
     current_policy = get_policy_file(compare)
     _, score_before, _, _ = check_policy_accuracy(test_data, current_policy, batch_size, compare)
     data = {}
-    i=0
+    i = 0
 
-    while score <.9 and i<10:
-        print('score is', score)
-        current_policy, score, correct_labelled, incorrect_labelled = check_policy_accuracy(train_data, current_policy, batch_size, compare)
-        data[i]=[current_policy, score, correct_labelled, incorrect_labelled]
-        AGENT_IMPROVEMENT = POLICY_MUTATE_PROMPT_TEMPLATE.format(original_policy = current_policy, correct_answers = correct_labelled, incorrect_answers = incorrect_labelled)
-        model = ChatModel(model="gpt-3.5-turbo-1106", temperature=0.5, top_p=0.5, max_tokens=700, seed=42)
+    while score < 0.9 and i < 10:
+        print("score is", score)
+        current_policy, score, correct_labelled, incorrect_labelled = check_policy_accuracy(
+            train_data, current_policy, batch_size, compare
+        )
+        data[i] = [current_policy, score, correct_labelled, incorrect_labelled]
+        AGENT_IMPROVEMENT = POLICY_MUTATE_PROMPT_TEMPLATE.format(
+            original_policy=current_policy,
+            correct_answers=correct_labelled,
+            incorrect_answers=incorrect_labelled,
+        )
+        model = ChatModel(
+            model="gpt-3.5-turbo-1106", temperature=0.5, top_p=0.5, max_tokens=700, seed=42
+        )
         try:
-            current_policyNew= model.create_chat_completion(prompt_improvement_character_prompt, AGENT_IMPROVEMENT, output_format="simple")
-            if current_policyNew!= None:
-                current_policy=current_policyNew
-        except:
+            current_policyNew = model.create_chat_completion(
+                prompt_improvement_character_prompt, AGENT_IMPROVEMENT, output_format="simple"
+            )
+            if current_policyNew is not None:
+                current_policy = current_policyNew
+        except Exception:
             pass
-        save_as_csv(data, f"results/csv/policy_mutation_snapshot_{compare_type}_compare{compare}.csv")
-        i+=1
+        save_as_csv(
+            data, f"results/csv/policy_mutation_snapshot_{compare_type}_compare{compare}.csv"
+        )
+        i += 1
 
-    _, score_after, _, _, = check_policy_accuracy(test_data, current_policy, batch_size, compare)
+    (
+        _,
+        score_after,
+        _,
+        _,
+    ) = check_policy_accuracy(test_data, current_policy, batch_size, compare)
     data["final scores"] = [score_before, score_after]
     save_as_csv(data, output)
     return current_policy

--- a/automated_llm_eval/prompts.py
+++ b/automated_llm_eval/prompts.py
@@ -1,5 +1,10 @@
 from langchain.prompts.prompt import PromptTemplate
 
+GPT_SYSTEM_PROMPT = (
+    "You are an expert AI agent, possessing an in-depth knowledge and expertise within "
+    "the healthcare and medical domain."
+)
+
 # The first prompt template is a simple QA template, which is used when querying the model for the first time
 DEFAULT_QA_PROMPT_TMPL = (
     "You are an expert AI agent that strictly follows the guidelines given below.\n"
@@ -9,7 +14,7 @@ DEFAULT_QA_PROMPT_TMPL = (
 )
 
 DEFAULT_QA_PROMPT = PromptTemplate(
-    input_variables=["question"], 
+    input_variables=["question"],
     template=DEFAULT_QA_PROMPT_TMPL,
 )
 
@@ -42,12 +47,13 @@ DEFAULT_REFINE_PROMPT_TMPL = (
 )
 
 DEFAULT_REFINE_PROMPT = PromptTemplate(
-    input_variables=["question", 
-                     "existing_answer", 
-                     "safety_gpt_response", 
-                     "ethics_gpt_response", 
-                     "clinician_gpt_response"
-                    ],
+    input_variables=[
+        "question",
+        "existing_answer",
+        "safety_gpt_response",
+        "ethics_gpt_response",
+        "clinician_gpt_response",
+    ],
     template=DEFAULT_REFINE_PROMPT_TMPL,
 )
 
@@ -70,17 +76,21 @@ DEFAULT_AGENT_PROMPT_TMPL = (
 )
 
 DEFAULT_AGENT_PROMPT = PromptTemplate(
-    input_variables=["question", 
-                     "existing_answer", 
-                     "agent_response", 
-                     "agent_guideline", 
-                    ],
+    input_variables=[
+        "question",
+        "existing_answer",
+        "agent_response",
+        "agent_guideline",
+    ],
     template=DEFAULT_AGENT_PROMPT_TMPL,
 )
 
 SCORE_RETRIEVAL_PROMPT = PromptTemplate(
-                input_variables=["response" ],
-                template=("Read the following response and respond with just the given score number. You should only return a numerical value with no words, letters, or punctuation:{response}."))
+    input_variables=["response"],
+    template=(
+        "Read the following response and respond with just the given score number. You should only return a numerical value with no words, letters, or punctuation:{response}."
+    ),
+)
 
 score_retrieval_character_prompt = "You are an AI system that can read text and return the numerical score that is included in the text."
 
@@ -125,8 +135,8 @@ COMPARE_AGENT_PROMPT_TMPL = (
 )
 
 COMPARE_AGENT_PROMPT = PromptTemplate(
-    input_variables = ["source", "current_policy", "summary_a", "summary_b"],
-    template = COMPARE_AGENT_PROMPT_TMPL,
+    input_variables=["source", "current_policy", "summary_a", "summary_b"],
+    template=COMPARE_AGENT_PROMPT_TMPL,
 )
 
 QA_AGENT_PROMPT_TMPL = (
@@ -135,6 +145,6 @@ QA_AGENT_PROMPT_TMPL = (
 )
 
 QA_AGENT_PROMPT = PromptTemplate(
-    input_variables = ["statement", "current_policy"],
-    template = QA_AGENT_PROMPT_TMPL,
+    input_variables=["statement", "current_policy"],
+    template=QA_AGENT_PROMPT_TMPL,
 )

--- a/notebooks/dev_notebook.ipynb
+++ b/notebooks/dev_notebook.ipynb
@@ -9,20 +9,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "ChatModel(sync_client=<openai.OpenAI object at 0x11ca88d90>, async_client=<openai.AsyncOpenAI object at 0x11caac1d0>, model='gpt-3.5-turbo-1106', temperature=0.9, top_p=0.9, max_tokens=None, n=1, seed=None)"
-      ]
-     },
-     "execution_count": 1,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "import pandas as pd\n",
     "\n",
@@ -37,20 +26,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "ChatModel(sync_client=<openai.OpenAI object at 0x11f488ed0>, async_client=<openai.AsyncOpenAI object at 0x11f4ac390>, model='gpt-3.5-turbo-1106', temperature=0.5, top_p=0.5, max_tokens=300, n=1, seed=42)"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# You can adjust other model settings globally for all API calls\n",
     "model2 = ChatModel(model=\"gpt-3.5-turbo-1106\", temperature=0.5, top_p=0.5, max_tokens=300, seed=42)\n",
@@ -59,20 +37,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "ChatModel(sync_client=<openai.OpenAI object at 0x11f488ed0>, async_client=<openai.AsyncOpenAI object at 0x11f4ac390>, model='gpt-3.5-turbo-1106', temperature=0.5, top_p=0.5, max_tokens=None, n=1, seed=42)"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# `max_tokens = None` means no max_token limit (this is the default)\n",
     "model2 = ChatModel(model=\"gpt-3.5-turbo-1106\", temperature=0.5, top_p=0.5, max_tokens=None, seed=42)\n",
@@ -88,17 +55,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Sure! Did you hear about the apple who went to the doctor? It wasn't feeling well, so the doctor said, \"You're just a little too core-ny!\"\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Make API call, get response message.\n",
     "# Note: `output_format = \"simple\"`\n",
@@ -112,17 +71,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "ChatCompletion(id='chatcmpl-8LHFVTIKmcNyrmyoBng465aJUzPmJ', choices=[Choice(finish_reason='stop', index=0, message=ChatCompletionMessage(content='Sure! Did you hear about the apple that went to a comedy club? It was a real \"core\" comedian!', role='assistant', function_call=None, tool_calls=None))], created=1700081885, model='gpt-3.5-turbo-1106', object='chat.completion', system_fingerprint='fp_eeff13170a', usage=CompletionUsage(completion_tokens=24, prompt_tokens=24, total_tokens=48))\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Make API call, get original ChatCompletion object.\n",
     "# Note: `output_format = None`\n",
@@ -136,17 +87,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Bundle(id='chatcmpl-8LHFWxY85RSdhc9Jur0LEwdcuhVIP', system_message='You are a joke telling machine.', user_message='Tell me something about apples.', response_message='Sure! Did you hear about the apple that joined a band? It was a real \"fruit\" musician!', created_time=1700081886, model='gpt-3.5-turbo-1106', total_tokens=46, prompt_tokens=24, completion_tokens=22, seed=None, temperature=0.9, top_p=0.9, max_tokens=None)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Make API call, get response packaged with input + metadata.\n",
     "# Note: `output_format = \"bundle\"`\n",
@@ -160,17 +103,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'id': 'chatcmpl-8LHFX3WIvSFJwf6tdnjoQ9H4Ix6XO', 'system_message': 'You are a joke telling machine.', 'user_message': 'Tell me something about apples.', 'response_message': \"Why did the apple go to the doctor? Because it wasn't peeling well!\", 'created_time': 1700081887, 'model': 'gpt-3.5-turbo-1106', 'total_tokens': 41, 'prompt_tokens': 24, 'completion_tokens': 17, 'seed': None, 'temperature': 0.9, 'top_p': 0.9, 'max_tokens': None}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Make API call, get MessageBundle as a dict.\n",
     "# Note: `output_format = \"bundle_dict\"`\n",
@@ -184,33 +119,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "id                              chatcmpl-8LHFX3WIvSFJwf6tdnjoQ9H4Ix6XO\n",
-       "system_message                         You are a joke telling machine.\n",
-       "user_message                           Tell me something about apples.\n",
-       "response_message     Why did the apple go to the doctor? Because it...\n",
-       "created_time                                                1700081887\n",
-       "model                                               gpt-3.5-turbo-1106\n",
-       "total_tokens                                                        41\n",
-       "prompt_tokens                                                       24\n",
-       "completion_tokens                                                   17\n",
-       "seed                                                              None\n",
-       "temperature                                                        0.9\n",
-       "top_p                                                              0.9\n",
-       "max_tokens                                                        None\n",
-       "dtype: object"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Message bundle dict can be converted into pandas Series easily\n",
     "s = pd.Series(bundle_dict)\n",
@@ -219,209 +130,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "be1fffae60364ee4b5213c43622eb71a",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Output()"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
-      ],
-      "text/plain": []
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>id</th>\n",
-       "      <th>system_message</th>\n",
-       "      <th>user_message</th>\n",
-       "      <th>response_message</th>\n",
-       "      <th>created_time</th>\n",
-       "      <th>model</th>\n",
-       "      <th>total_tokens</th>\n",
-       "      <th>prompt_tokens</th>\n",
-       "      <th>completion_tokens</th>\n",
-       "      <th>seed</th>\n",
-       "      <th>temperature</th>\n",
-       "      <th>top_p</th>\n",
-       "      <th>max_tokens</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>chatcmpl-8LHU4nKCzGGA8Kv89eWrza4jckce9</td>\n",
-       "      <td>You are a joke telling machine.</td>\n",
-       "      <td>Tell me something about apples.</td>\n",
-       "      <td>Sure! Did you know that apples are actually a ...</td>\n",
-       "      <td>1700082788</td>\n",
-       "      <td>gpt-3.5-turbo-1106</td>\n",
-       "      <td>54</td>\n",
-       "      <td>24</td>\n",
-       "      <td>30</td>\n",
-       "      <td>None</td>\n",
-       "      <td>0.4</td>\n",
-       "      <td>0.9</td>\n",
-       "      <td>None</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>chatcmpl-8LHU5ijJ7oMYWhRTKM62pGZwYsOJO</td>\n",
-       "      <td>You are a joke telling machine.</td>\n",
-       "      <td>Tell me something about apples.</td>\n",
-       "      <td>Why did the apple go to the doctor? Because it...</td>\n",
-       "      <td>1700082789</td>\n",
-       "      <td>gpt-3.5-turbo-1106</td>\n",
-       "      <td>41</td>\n",
-       "      <td>24</td>\n",
-       "      <td>17</td>\n",
-       "      <td>None</td>\n",
-       "      <td>0.4</td>\n",
-       "      <td>0.9</td>\n",
-       "      <td>None</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>chatcmpl-8LHU6ddSETdEW3giO2ywpp2H5MLzU</td>\n",
-       "      <td>You are a joke telling machine.</td>\n",
-       "      <td>Tell me something about apples.</td>\n",
-       "      <td>Why did the apple go to the doctor? Because it...</td>\n",
-       "      <td>1700082790</td>\n",
-       "      <td>gpt-3.5-turbo-1106</td>\n",
-       "      <td>41</td>\n",
-       "      <td>24</td>\n",
-       "      <td>17</td>\n",
-       "      <td>None</td>\n",
-       "      <td>0.4</td>\n",
-       "      <td>0.9</td>\n",
-       "      <td>None</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>chatcmpl-8LHU7OgtZAXMKdp6xRQeRy6h7o3yg</td>\n",
-       "      <td>You are a joke telling machine.</td>\n",
-       "      <td>Tell me something about apples.</td>\n",
-       "      <td>Why did the apple go to the doctor? Because it...</td>\n",
-       "      <td>1700082791</td>\n",
-       "      <td>gpt-3.5-turbo-1106</td>\n",
-       "      <td>41</td>\n",
-       "      <td>24</td>\n",
-       "      <td>17</td>\n",
-       "      <td>None</td>\n",
-       "      <td>0.4</td>\n",
-       "      <td>0.9</td>\n",
-       "      <td>None</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>chatcmpl-8LHU7VP1FbjeKYCOdfF2xZhJ18OUj</td>\n",
-       "      <td>You are a joke telling machine.</td>\n",
-       "      <td>Tell me something about apples.</td>\n",
-       "      <td>Sure! Did you hear about the apple that went t...</td>\n",
-       "      <td>1700082791</td>\n",
-       "      <td>gpt-3.5-turbo-1106</td>\n",
-       "      <td>49</td>\n",
-       "      <td>24</td>\n",
-       "      <td>25</td>\n",
-       "      <td>None</td>\n",
-       "      <td>0.4</td>\n",
-       "      <td>0.9</td>\n",
-       "      <td>None</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                                       id                   system_message  \\\n",
-       "0  chatcmpl-8LHU4nKCzGGA8Kv89eWrza4jckce9  You are a joke telling machine.   \n",
-       "1  chatcmpl-8LHU5ijJ7oMYWhRTKM62pGZwYsOJO  You are a joke telling machine.   \n",
-       "2  chatcmpl-8LHU6ddSETdEW3giO2ywpp2H5MLzU  You are a joke telling machine.   \n",
-       "3  chatcmpl-8LHU7OgtZAXMKdp6xRQeRy6h7o3yg  You are a joke telling machine.   \n",
-       "4  chatcmpl-8LHU7VP1FbjeKYCOdfF2xZhJ18OUj  You are a joke telling machine.   \n",
-       "\n",
-       "                      user_message  \\\n",
-       "0  Tell me something about apples.   \n",
-       "1  Tell me something about apples.   \n",
-       "2  Tell me something about apples.   \n",
-       "3  Tell me something about apples.   \n",
-       "4  Tell me something about apples.   \n",
-       "\n",
-       "                                    response_message  created_time  \\\n",
-       "0  Sure! Did you know that apples are actually a ...    1700082788   \n",
-       "1  Why did the apple go to the doctor? Because it...    1700082789   \n",
-       "2  Why did the apple go to the doctor? Because it...    1700082790   \n",
-       "3  Why did the apple go to the doctor? Because it...    1700082791   \n",
-       "4  Sure! Did you hear about the apple that went t...    1700082791   \n",
-       "\n",
-       "                model  total_tokens  prompt_tokens  completion_tokens  seed  \\\n",
-       "0  gpt-3.5-turbo-1106            54             24                 30  None   \n",
-       "1  gpt-3.5-turbo-1106            41             24                 17  None   \n",
-       "2  gpt-3.5-turbo-1106            41             24                 17  None   \n",
-       "3  gpt-3.5-turbo-1106            41             24                 17  None   \n",
-       "4  gpt-3.5-turbo-1106            49             24                 25  None   \n",
-       "\n",
-       "   temperature  top_p max_tokens  \n",
-       "0          0.4    0.9       None  \n",
-       "1          0.4    0.9       None  \n",
-       "2          0.4    0.9       None  \n",
-       "3          0.4    0.9       None  \n",
-       "4          0.4    0.9       None  "
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Multiple message bundle dicts can be converted into pandas DataFrame\n",
     "# NOTE: if an API call fails, then `None` will be returned. `None` items cannot\n",
@@ -444,17 +155,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'id': 'chatcmpl-8LHFe3TwPLPVF5apK6rbRGC34iLR9', 'system_message': 'You are a joke telling machine.', 'user_message': 'Tell me something about apples.', 'response_message': \"Why did the apple go to the doctor? Because it wasn't peeling well!\", 'created_time': 1700081894, 'model': 'gpt-3.5-turbo-1106', 'total_tokens': 41, 'prompt_tokens': 24, 'completion_tokens': 17, 'seed': None, 'temperature': 0.9, 'top_p': 0.9, 'max_tokens': None}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# If an API call fails, this method will automatically retry and make another API call.\n",
     "# By default it will retry 5 times.  We can change this value to 2.\n",
@@ -469,17 +172,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'id': 'chatcmpl-8LHFfL1BpS9A4Z2dk6EIpQHnIXVP4', 'system_message': 'You are a joke telling machine.', 'user_message': 'Tell me something about apples.', 'response_message': \"Why did the apple go to the doctor? Because it wasn't peeling well!\", 'created_time': 1700081895, 'model': 'gpt-3.5-turbo-1106', 'total_tokens': 41, 'prompt_tokens': 24, 'completion_tokens': 17, 'seed': None, 'temperature': 0.9, 'top_p': 0.9, 'max_tokens': None}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# The `create_chat_completion` method is syntactic sugar for `chat_completion`.\n",
     "# It simply formats the message for us.\n",
@@ -514,20 +209,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "ChatCompletion(id='chatcmpl-8LHFiXgCVD8lu3ncjwKD0ULlgi5Rx', choices=[Choice(finish_reason='stop', index=0, message=ChatCompletionMessage(content='Sure! Did you hear about the apple who went to the doctor? The doctor said, \"You\\'re not looking so hot, you should probably see a cider-ist!\"', role='assistant', function_call=None, tool_calls=None))], created=1700081898, model='gpt-3.5-turbo-1106', object='chat.completion', system_fingerprint='fp_eeff13170a', usage=CompletionUsage(completion_tokens=35, prompt_tokens=24, total_tokens=59))"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "system_message = \"You are a joke telling machine.\"\n",
     "user_message = \"Tell me something about apples.\"\n",
@@ -542,29 +226,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[[{'role': 'system', 'content': 'You are a joke telling machine.'},\n",
-       "  {'role': 'user', 'content': 'Tell me something about apples.'}],\n",
-       " [{'role': 'system', 'content': 'You are a joke telling machine.'},\n",
-       "  {'role': 'user', 'content': 'Tell me something about apples.'}],\n",
-       " [{'role': 'system', 'content': 'You are a joke telling machine.'},\n",
-       "  {'role': 'user', 'content': 'Tell me something about apples.'}],\n",
-       " [{'role': 'system', 'content': 'You are a joke telling machine.'},\n",
-       "  {'role': 'user', 'content': 'Tell me something about apples.'}],\n",
-       " [{'role': 'system', 'content': 'You are a joke telling machine.'},\n",
-       "  {'role': 'user', 'content': 'Tell me something about apples.'}]]"
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Duplicate Messages x 5 times so that we can make 5 API calls\n",
     "messages_list = [messages] * 5\n",
@@ -573,209 +237,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "67669804ad9a4e9b9b96c76be94e0e8b",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Output()"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
-      ],
-      "text/plain": []
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>id</th>\n",
-       "      <th>system_message</th>\n",
-       "      <th>user_message</th>\n",
-       "      <th>response_message</th>\n",
-       "      <th>created_time</th>\n",
-       "      <th>model</th>\n",
-       "      <th>total_tokens</th>\n",
-       "      <th>prompt_tokens</th>\n",
-       "      <th>completion_tokens</th>\n",
-       "      <th>seed</th>\n",
-       "      <th>temperature</th>\n",
-       "      <th>top_p</th>\n",
-       "      <th>max_tokens</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>chatcmpl-8LHFkpQFlOy3Mm1kRU5ztKUBrGSvn</td>\n",
-       "      <td>You are a joke telling machine.</td>\n",
-       "      <td>Tell me something about apples.</td>\n",
-       "      <td>Why did the apple stop in the middle of the ro...</td>\n",
-       "      <td>1700081900</td>\n",
-       "      <td>gpt-3.5-turbo-1106</td>\n",
-       "      <td>43</td>\n",
-       "      <td>24</td>\n",
-       "      <td>19</td>\n",
-       "      <td>None</td>\n",
-       "      <td>0.9</td>\n",
-       "      <td>0.9</td>\n",
-       "      <td>None</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>chatcmpl-8LHFkcxmbRkorvjQ0rnqMdaA7jekx</td>\n",
-       "      <td>You are a joke telling machine.</td>\n",
-       "      <td>Tell me something about apples.</td>\n",
-       "      <td>Why did the apple go to the doctor? Because it...</td>\n",
-       "      <td>1700081900</td>\n",
-       "      <td>gpt-3.5-turbo-1106</td>\n",
-       "      <td>41</td>\n",
-       "      <td>24</td>\n",
-       "      <td>17</td>\n",
-       "      <td>None</td>\n",
-       "      <td>0.9</td>\n",
-       "      <td>0.9</td>\n",
-       "      <td>None</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>chatcmpl-8LHFl5eCUj6urcXpbH1QdD3p2zZ7U</td>\n",
-       "      <td>You are a joke telling machine.</td>\n",
-       "      <td>Tell me something about apples.</td>\n",
-       "      <td>Sure! Did you hear about the apple that went o...</td>\n",
-       "      <td>1700081901</td>\n",
-       "      <td>gpt-3.5-turbo-1106</td>\n",
-       "      <td>52</td>\n",
-       "      <td>24</td>\n",
-       "      <td>28</td>\n",
-       "      <td>None</td>\n",
-       "      <td>0.9</td>\n",
-       "      <td>0.9</td>\n",
-       "      <td>None</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>chatcmpl-8LHFm4YFHXxzZS8kGPvYPQDqahpXM</td>\n",
-       "      <td>You are a joke telling machine.</td>\n",
-       "      <td>Tell me something about apples.</td>\n",
-       "      <td>Sure! Did you hear about the apple that won th...</td>\n",
-       "      <td>1700081902</td>\n",
-       "      <td>gpt-3.5-turbo-1106</td>\n",
-       "      <td>51</td>\n",
-       "      <td>24</td>\n",
-       "      <td>27</td>\n",
-       "      <td>None</td>\n",
-       "      <td>0.9</td>\n",
-       "      <td>0.9</td>\n",
-       "      <td>None</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>chatcmpl-8LHFnBoOMlN4WsVJfctUsrjUJMRYC</td>\n",
-       "      <td>You are a joke telling machine.</td>\n",
-       "      <td>Tell me something about apples.</td>\n",
-       "      <td>Why did the apple break up with the banana?\\n\\...</td>\n",
-       "      <td>1700081903</td>\n",
-       "      <td>gpt-3.5-turbo-1106</td>\n",
-       "      <td>43</td>\n",
-       "      <td>24</td>\n",
-       "      <td>19</td>\n",
-       "      <td>None</td>\n",
-       "      <td>0.9</td>\n",
-       "      <td>0.9</td>\n",
-       "      <td>None</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                                       id                   system_message  \\\n",
-       "0  chatcmpl-8LHFkpQFlOy3Mm1kRU5ztKUBrGSvn  You are a joke telling machine.   \n",
-       "1  chatcmpl-8LHFkcxmbRkorvjQ0rnqMdaA7jekx  You are a joke telling machine.   \n",
-       "2  chatcmpl-8LHFl5eCUj6urcXpbH1QdD3p2zZ7U  You are a joke telling machine.   \n",
-       "3  chatcmpl-8LHFm4YFHXxzZS8kGPvYPQDqahpXM  You are a joke telling machine.   \n",
-       "4  chatcmpl-8LHFnBoOMlN4WsVJfctUsrjUJMRYC  You are a joke telling machine.   \n",
-       "\n",
-       "                      user_message  \\\n",
-       "0  Tell me something about apples.   \n",
-       "1  Tell me something about apples.   \n",
-       "2  Tell me something about apples.   \n",
-       "3  Tell me something about apples.   \n",
-       "4  Tell me something about apples.   \n",
-       "\n",
-       "                                    response_message  created_time  \\\n",
-       "0  Why did the apple stop in the middle of the ro...    1700081900   \n",
-       "1  Why did the apple go to the doctor? Because it...    1700081900   \n",
-       "2  Sure! Did you hear about the apple that went o...    1700081901   \n",
-       "3  Sure! Did you hear about the apple that won th...    1700081902   \n",
-       "4  Why did the apple break up with the banana?\\n\\...    1700081903   \n",
-       "\n",
-       "                model  total_tokens  prompt_tokens  completion_tokens  seed  \\\n",
-       "0  gpt-3.5-turbo-1106            43             24                 19  None   \n",
-       "1  gpt-3.5-turbo-1106            41             24                 17  None   \n",
-       "2  gpt-3.5-turbo-1106            52             24                 28  None   \n",
-       "3  gpt-3.5-turbo-1106            51             24                 27  None   \n",
-       "4  gpt-3.5-turbo-1106            43             24                 19  None   \n",
-       "\n",
-       "   temperature  top_p max_tokens  \n",
-       "0          0.9    0.9       None  \n",
-       "1          0.9    0.9       None  \n",
-       "2          0.9    0.9       None  \n",
-       "3          0.9    0.9       None  \n",
-       "4          0.9    0.9       None  "
-      ]
-     },
-     "execution_count": 14,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Use Async Chat Completions, limit to 2 concurrent API calls at any given time\n",
     "responses_list = await model.async_chat_completions(  # noqa: F704\n",
@@ -809,32 +273,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "In Callback. Messages: Message(messages=[{'role': 'system', 'content': 'You are a joke telling machine.'}, {'role': 'user', 'content': 'Tell me something about apples.'}], metadata={'a': 1})\n",
-      "In Callback. Response: Why did the apple stop in the middle of the road?\n",
-      "\n",
-      "Because it ran out of juice!\n",
-      "\n",
-      "\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "'Why did the apple stop in the middle of the road?\\n\\nBecause it ran out of juice!'"
-      ]
-     },
-     "execution_count": 15,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "system_message = \"You are a joke telling machine.\"\n",
     "user_message = \"Tell me something about apples.\"\n",
@@ -868,7 +309,7 @@
     "# - allow up to 1 retry.  If still fails/rejected after 1 retry, then will return `None`.\n",
     "response = model.chat_completion(\n",
     "    m,\n",
-    "    output_format=\"simple\",\n",
+    "    output_format=\"bundle_dict\",\n",
     "    validation_callback=validation_callback_fn,\n",
     "    num_retries=1,\n",
     ")\n",
@@ -877,22 +318,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[Message(messages=[{'role': 'system', 'content': 'You are a joke telling machine.'}, {'role': 'user', 'content': 'Tell me something about apples.'}], metadata={'a': 1}),\n",
-       " Message(messages=[{'role': 'system', 'content': 'You are a joke telling machine.'}, {'role': 'user', 'content': 'Tell me something about apples.'}], metadata={'a': 1}),\n",
-       " Message(messages=[{'role': 'system', 'content': 'You are a joke telling machine.'}, {'role': 'user', 'content': 'Tell me something about apples.'}], metadata={'b': 2})]"
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Multiple concurrent async chat completions using Message\n",
     "# NOTE: we make the 3rd Message with different metadata.  This should cause\n",
@@ -904,209 +332,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "0c9584a235e14604ab75d5d4f426c231",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Output()"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">In Callback. Messages: Message(messages=[{'role': 'system', 'content': 'You are a joke telling machine.'}, {'role':\n",
-       "'user', 'content': 'Tell me something about apples.'}], metadata={'a': 1})\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "In Callback. Messages: Message(messages=[{'role': 'system', 'content': 'You are a joke telling machine.'}, {'role':\n",
-       "'user', 'content': 'Tell me something about apples.'}], metadata={'a': 1})\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">In Callback. Response: Why did the apple go to the doctor? Because it wasn't peeling well!\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "In Callback. Response: Why did the apple go to the doctor? Because it wasn't peeling well!\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">In Callback. Messages: Message(messages=[{'role': 'system', 'content': 'You are a joke telling machine.'}, {'role':\n",
-       "'user', 'content': 'Tell me something about apples.'}], metadata={'a': 1})\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "In Callback. Messages: Message(messages=[{'role': 'system', 'content': 'You are a joke telling machine.'}, {'role':\n",
-       "'user', 'content': 'Tell me something about apples.'}], metadata={'a': 1})\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">In Callback. Response: Why did the apple stop in the middle of the road? Because it ran out of juice!\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "In Callback. Response: Why did the apple stop in the middle of the road? Because it ran out of juice!\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">In Callback. Messages: Message(messages=[{'role': 'system', 'content': 'You are a joke telling machine.'}, {'role':\n",
-       "'user', 'content': 'Tell me something about apples.'}], metadata={'b': 2})\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "In Callback. Messages: Message(messages=[{'role': 'system', 'content': 'You are a joke telling machine.'}, {'role':\n",
-       "'user', 'content': 'Tell me something about apples.'}], metadata={'b': 2})\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">In Callback. Response: Why did the apple go to the doctor? Because it wasn't peeling well!\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "In Callback. Response: Why did the apple go to the doctor? Because it wasn't peeling well!\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
-      ],
-      "text/plain": []
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Use Async Chat Completions, limit to 2 concurrent API calls at any given time & 1 retry\n",
     "responses_list = await model.async_chat_completions(  # noqa: F704\n",
@@ -1114,28 +342,15 @@
     "    num_concurrent=2,\n",
     "    num_retries=1,\n",
     "    validation_callback=validation_callback_fn,\n",
-    "    output_format=\"simple\",\n",
+    "    output_format=\"bundle_dict\",\n",
     ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[\"Why did the apple go to the doctor? Because it wasn't peeling well!\",\n",
-       " 'Why did the apple stop in the middle of the road? Because it ran out of juice!',\n",
-       " None]"
-      ]
-     },
-     "execution_count": 18,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Examine responses.\n",
     "# - We should get valid responses for the first 2 responses.\n",
@@ -1153,7 +368,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1171,59 +386,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "875366fc4688437789af768907e1c729",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Output()"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
-      ],
-      "text/plain": []
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "[Bundle(id='chatcmpl-8LHG0xLSG28e74jLvsIE7t7R9b1mm', system_message='You are a joke telling machine.', user_message='Tell me something about apples.', response_message='Why did the apple stop in the middle of the road? Because it ran out of juice!', created_time=1700081916, model='gpt-3.5-turbo-1106', total_tokens=43, prompt_tokens=24, completion_tokens=19, seed=None, temperature=0.9, top_p=0.9, max_tokens=None),\n",
-       " Bundle(id='chatcmpl-8LHG02RSYvxNGW0IfApWHnwaJv29n', system_message='You are a joke telling machine.', user_message='Tell me something about apples.', response_message='Why did the apple go to therapy? Because it had a core issue!', created_time=1700081916, model='gpt-3.5-turbo-1106', total_tokens=39, prompt_tokens=24, completion_tokens=15, seed=None, temperature=0.9, top_p=0.9, max_tokens=None),\n",
-       " Bundle(id='chatcmpl-8LHG1HlqTAMrReI3wB66y2CvKZLRY', system_message='You are a joke telling machine.', user_message='Tell me something about apples.', response_message='Why did the apple go to therapy? Because it had too many cores issues!', created_time=1700081917, model='gpt-3.5-turbo-1106', total_tokens=40, prompt_tokens=24, completion_tokens=16, seed=None, temperature=0.9, top_p=0.9, max_tokens=None)]"
-      ]
-     },
-     "execution_count": 20,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Up until now, we have used `await` to call async functions and wait for their completion.\n",
     "# However, `await` this can only be used within async functions.\n",
@@ -1236,59 +401,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a161d5fbad5b407e865deab6bd6f8bf6",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Output()"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
-      ],
-      "text/plain": []
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "[Bundle(id='chatcmpl-8LHG5m7piUbUsBWqFS2nwuaQuOhVu', system_message='You are a joke telling machine.', user_message='Tell me something about apples.', response_message=\"Why did the apple break up with the orange? Because it couldn't find a core connection!\", created_time=1700081921, model='gpt-3.5-turbo-1106', total_tokens=43, prompt_tokens=24, completion_tokens=19, seed=None, temperature=0.9, top_p=0.9, max_tokens=None),\n",
-       " Bundle(id='chatcmpl-8LHG5cvTHsyd6QBL33g6hTKqtv6SP', system_message='You are a joke telling machine.', user_message='Tell me something about apples.', response_message='Sure! Did you hear about the apple that went on a date with a banana? It was a fruit match made in heaven!', created_time=1700081921, model='gpt-3.5-turbo-1106', total_tokens=50, prompt_tokens=24, completion_tokens=26, seed=None, temperature=0.9, top_p=0.9, max_tokens=None),\n",
-       " Bundle(id='chatcmpl-8LHG6HJ0Zs3AfIDArMRRoyzp1Cq6X', system_message='You are a joke telling machine.', user_message='Tell me something about apples.', response_message='Why did the apple go to school?\\n\\nTo get a little bit of \"core\" education!', created_time=1700081922, model='gpt-3.5-turbo-1106', total_tokens=43, prompt_tokens=24, completion_tokens=19, seed=None, temperature=0.9, top_p=0.9, max_tokens=None)]"
-      ]
-     },
-     "execution_count": 21,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# We have created a helper function to address this issue.\n",
     "#\n",

--- a/notebooks/dev_notebook.ipynb
+++ b/notebooks/dev_notebook.ipynb
@@ -9,9 +9,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "ChatModel(sync_client=<openai.OpenAI object at 0x11d41d050>, async_client=<openai.AsyncOpenAI object at 0x11d440390>, model='gpt-3.5-turbo-1106', temperature=0.9, top_p=0.9, max_tokens=None, n=1, seed=None)"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "import pandas as pd\n",
     "\n",
@@ -26,9 +37,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "ChatModel(sync_client=<openai.OpenAI object at 0x11ca88c90>, async_client=<openai.AsyncOpenAI object at 0x11caac150>, model='gpt-3.5-turbo-1106', temperature=0.5, top_p=0.5, max_tokens=300, n=1, seed=42)"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# You can adjust other model settings globally for all API calls\n",
     "model2 = ChatModel(model=\"gpt-3.5-turbo-1106\", temperature=0.5, top_p=0.5, max_tokens=300, seed=42)\n",
@@ -37,9 +59,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "ChatModel(sync_client=<openai.OpenAI object at 0x11ca88c90>, async_client=<openai.AsyncOpenAI object at 0x11caac150>, model='gpt-3.5-turbo-1106', temperature=0.5, top_p=0.5, max_tokens=None, n=1, seed=42)"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# `max_tokens = None` means no max_token limit (this is the default)\n",
     "model2 = ChatModel(model=\"gpt-3.5-turbo-1106\", temperature=0.5, top_p=0.5, max_tokens=None, seed=42)\n",
@@ -55,9 +88,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sure! Did you hear about the apple who went to the doctor? It said, \"I'm feeling a little rotten.\"\n"
+     ]
+    }
+   ],
    "source": [
     "# Make API call, get response message.\n",
     "# Note: `output_format = \"simple\"`\n",
@@ -71,9 +112,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ChatCompletion(id='chatcmpl-8LIEizorIQmTB8O3C8YwAlafmnGGl', choices=[Choice(finish_reason='stop', index=0, message=ChatCompletionMessage(content=\"Why did the apple go to the doctor? Because it wasn't peeling well!\", role='assistant', function_call=None, tool_calls=None))], created=1700085680, model='gpt-3.5-turbo-1106', object='chat.completion', system_fingerprint='fp_eeff13170a', usage=CompletionUsage(completion_tokens=17, prompt_tokens=24, total_tokens=41))\n"
+     ]
+    }
+   ],
    "source": [
     "# Make API call, get original ChatCompletion object.\n",
     "# Note: `output_format = None`\n",
@@ -87,9 +136,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Bundle(id='chatcmpl-8LIEj0bm89tEdBtdqm2gHzS5Ng8kg', system_message='You are a joke telling machine.', user_message='Tell me something about apples.', metadata=None, response_message='Why did the apple stop in the middle of the road? Because it ran out of juice!', created_time=1700085681, model='gpt-3.5-turbo-1106', total_tokens=43, prompt_tokens=24, completion_tokens=19, seed=None, temperature=0.9, top_p=0.9, max_tokens=None)\n"
+     ]
+    }
+   ],
    "source": [
     "# Make API call, get response packaged with input + metadata.\n",
     "# Note: `output_format = \"bundle\"`\n",
@@ -103,9 +160,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'id': 'chatcmpl-8LIElldN2tGoBkLDl2dBdVrWWPWfJ', 'system_message': 'You are a joke telling machine.', 'user_message': 'Tell me something about apples.', 'metadata': None, 'response_message': 'Why did the apple go to therapy? Because it had too many core issues!', 'created_time': 1700085683, 'model': 'gpt-3.5-turbo-1106', 'total_tokens': 40, 'prompt_tokens': 24, 'completion_tokens': 16, 'seed': None, 'temperature': 0.9, 'top_p': 0.9, 'max_tokens': None}\n"
+     ]
+    }
+   ],
    "source": [
     "# Make API call, get MessageBundle as a dict.\n",
     "# Note: `output_format = \"bundle_dict\"`\n",
@@ -119,9 +184,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "id                              chatcmpl-8LIElldN2tGoBkLDl2dBdVrWWPWfJ\n",
+       "system_message                         You are a joke telling machine.\n",
+       "user_message                           Tell me something about apples.\n",
+       "metadata                                                          None\n",
+       "response_message     Why did the apple go to therapy? Because it ha...\n",
+       "created_time                                                1700085683\n",
+       "model                                               gpt-3.5-turbo-1106\n",
+       "total_tokens                                                        40\n",
+       "prompt_tokens                                                       24\n",
+       "completion_tokens                                                   16\n",
+       "seed                                                              None\n",
+       "temperature                                                        0.9\n",
+       "top_p                                                              0.9\n",
+       "max_tokens                                                        None\n",
+       "dtype: object"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Message bundle dict can be converted into pandas Series easily\n",
     "s = pd.Series(bundle_dict)\n",
@@ -130,9 +220,215 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d6567c382d9f42828a1c17dee28d44b3",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Output()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
+      ],
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>system_message</th>\n",
+       "      <th>user_message</th>\n",
+       "      <th>metadata</th>\n",
+       "      <th>response_message</th>\n",
+       "      <th>created_time</th>\n",
+       "      <th>model</th>\n",
+       "      <th>total_tokens</th>\n",
+       "      <th>prompt_tokens</th>\n",
+       "      <th>completion_tokens</th>\n",
+       "      <th>seed</th>\n",
+       "      <th>temperature</th>\n",
+       "      <th>top_p</th>\n",
+       "      <th>max_tokens</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>chatcmpl-8LIEvZuvS3EzxVgGWtDQAeSt0v7gy</td>\n",
+       "      <td>You are a joke telling machine.</td>\n",
+       "      <td>Tell me something about apples.</td>\n",
+       "      <td>None</td>\n",
+       "      <td>Why did the apple go to the doctor? Because it...</td>\n",
+       "      <td>1700085693</td>\n",
+       "      <td>gpt-3.5-turbo-1106</td>\n",
+       "      <td>41</td>\n",
+       "      <td>24</td>\n",
+       "      <td>17</td>\n",
+       "      <td>None</td>\n",
+       "      <td>0.4</td>\n",
+       "      <td>0.9</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>chatcmpl-8LIEwQDOYw4kAjsTy6sybftU3lcJt</td>\n",
+       "      <td>You are a joke telling machine.</td>\n",
+       "      <td>Tell me something about apples.</td>\n",
+       "      <td>None</td>\n",
+       "      <td>Why did the apple go to the doctor? Because it...</td>\n",
+       "      <td>1700085694</td>\n",
+       "      <td>gpt-3.5-turbo-1106</td>\n",
+       "      <td>41</td>\n",
+       "      <td>24</td>\n",
+       "      <td>17</td>\n",
+       "      <td>None</td>\n",
+       "      <td>0.4</td>\n",
+       "      <td>0.9</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>chatcmpl-8LIEwO36JC3epmP7r3nUKzTuJeU2d</td>\n",
+       "      <td>You are a joke telling machine.</td>\n",
+       "      <td>Tell me something about apples.</td>\n",
+       "      <td>None</td>\n",
+       "      <td>Sure! Did you hear about the apple who went to...</td>\n",
+       "      <td>1700085694</td>\n",
+       "      <td>gpt-3.5-turbo-1106</td>\n",
+       "      <td>60</td>\n",
+       "      <td>24</td>\n",
+       "      <td>36</td>\n",
+       "      <td>None</td>\n",
+       "      <td>0.4</td>\n",
+       "      <td>0.9</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>chatcmpl-8LIExaDW5XR6XQUcQfc6HE0lFGYmb</td>\n",
+       "      <td>You are a joke telling machine.</td>\n",
+       "      <td>Tell me something about apples.</td>\n",
+       "      <td>None</td>\n",
+       "      <td>Why did the apple go to the doctor? Because it...</td>\n",
+       "      <td>1700085695</td>\n",
+       "      <td>gpt-3.5-turbo-1106</td>\n",
+       "      <td>41</td>\n",
+       "      <td>24</td>\n",
+       "      <td>17</td>\n",
+       "      <td>None</td>\n",
+       "      <td>0.4</td>\n",
+       "      <td>0.9</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>chatcmpl-8LIEyDt4t3SfCUdkEDnBYVJLFsamz</td>\n",
+       "      <td>You are a joke telling machine.</td>\n",
+       "      <td>Tell me something about apples.</td>\n",
+       "      <td>None</td>\n",
+       "      <td>Why did the apple go to the doctor? Because it...</td>\n",
+       "      <td>1700085696</td>\n",
+       "      <td>gpt-3.5-turbo-1106</td>\n",
+       "      <td>41</td>\n",
+       "      <td>24</td>\n",
+       "      <td>17</td>\n",
+       "      <td>None</td>\n",
+       "      <td>0.4</td>\n",
+       "      <td>0.9</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                       id                   system_message  \\\n",
+       "0  chatcmpl-8LIEvZuvS3EzxVgGWtDQAeSt0v7gy  You are a joke telling machine.   \n",
+       "1  chatcmpl-8LIEwQDOYw4kAjsTy6sybftU3lcJt  You are a joke telling machine.   \n",
+       "2  chatcmpl-8LIEwO36JC3epmP7r3nUKzTuJeU2d  You are a joke telling machine.   \n",
+       "3  chatcmpl-8LIExaDW5XR6XQUcQfc6HE0lFGYmb  You are a joke telling machine.   \n",
+       "4  chatcmpl-8LIEyDt4t3SfCUdkEDnBYVJLFsamz  You are a joke telling machine.   \n",
+       "\n",
+       "                      user_message metadata  \\\n",
+       "0  Tell me something about apples.     None   \n",
+       "1  Tell me something about apples.     None   \n",
+       "2  Tell me something about apples.     None   \n",
+       "3  Tell me something about apples.     None   \n",
+       "4  Tell me something about apples.     None   \n",
+       "\n",
+       "                                    response_message  created_time  \\\n",
+       "0  Why did the apple go to the doctor? Because it...    1700085693   \n",
+       "1  Why did the apple go to the doctor? Because it...    1700085694   \n",
+       "2  Sure! Did you hear about the apple who went to...    1700085694   \n",
+       "3  Why did the apple go to the doctor? Because it...    1700085695   \n",
+       "4  Why did the apple go to the doctor? Because it...    1700085696   \n",
+       "\n",
+       "                model  total_tokens  prompt_tokens  completion_tokens  seed  \\\n",
+       "0  gpt-3.5-turbo-1106            41             24                 17  None   \n",
+       "1  gpt-3.5-turbo-1106            41             24                 17  None   \n",
+       "2  gpt-3.5-turbo-1106            60             24                 36  None   \n",
+       "3  gpt-3.5-turbo-1106            41             24                 17  None   \n",
+       "4  gpt-3.5-turbo-1106            41             24                 17  None   \n",
+       "\n",
+       "   temperature  top_p max_tokens  \n",
+       "0          0.4    0.9       None  \n",
+       "1          0.4    0.9       None  \n",
+       "2          0.4    0.9       None  \n",
+       "3          0.4    0.9       None  \n",
+       "4          0.4    0.9       None  "
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Multiple message bundle dicts can be converted into pandas DataFrame\n",
     "# NOTE: if an API call fails, then `None` will be returned. `None` items cannot\n",
@@ -155,9 +451,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'id': 'chatcmpl-8LIEzFIdVzBSsJJ21hng3AZI8PRLc', 'system_message': 'You are a joke telling machine.', 'user_message': 'Tell me something about apples.', 'metadata': None, 'response_message': \"Sure, here's a joke about apples:\\n\\nWhy did the apple stop in the middle of the road?\\n\\nBecause it ran out of juice!\", 'created_time': 1700085697, 'model': 'gpt-3.5-turbo-1106', 'total_tokens': 52, 'prompt_tokens': 24, 'completion_tokens': 28, 'seed': None, 'temperature': 0.9, 'top_p': 0.9, 'max_tokens': None}\n"
+     ]
+    }
+   ],
    "source": [
     "# If an API call fails, this method will automatically retry and make another API call.\n",
     "# By default it will retry 5 times.  We can change this value to 2.\n",
@@ -172,9 +476,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'id': 'chatcmpl-8LIF1fVbUbsko55IgU36Eb1EstOiz', 'system_message': 'You are a joke telling machine.', 'user_message': 'Tell me something about apples.', 'metadata': None, 'response_message': \"Why did the apple go to the doctor? Because it wasn't peeling well!\", 'created_time': 1700085699, 'model': 'gpt-3.5-turbo-1106', 'total_tokens': 41, 'prompt_tokens': 24, 'completion_tokens': 17, 'seed': None, 'temperature': 0.9, 'top_p': 0.9, 'max_tokens': None}\n"
+     ]
+    }
+   ],
    "source": [
     "# The `create_chat_completion` method is syntactic sugar for `chat_completion`.\n",
     "# It simply formats the message for us.\n",
@@ -209,9 +521,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "ChatCompletion(id='chatcmpl-8LIL18DbBB8s5U3msQG6anMD6DQPJ', choices=[Choice(finish_reason='stop', index=0, message=ChatCompletionMessage(content='Why did the apple stop in the middle of the road?\\n\\nBecause it ran out of juice!', role='assistant', function_call=None, tool_calls=None))], created=1700086071, model='gpt-3.5-turbo-1106', object='chat.completion', system_fingerprint='fp_eeff13170a', usage=CompletionUsage(completion_tokens=19, prompt_tokens=24, total_tokens=43))"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "system_message = \"You are a joke telling machine.\"\n",
     "user_message = \"Tell me something about apples.\"\n",
@@ -226,9 +549,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[[{'role': 'system', 'content': 'You are a joke telling machine.'},\n",
+       "  {'role': 'user', 'content': 'Tell me something about apples.'}],\n",
+       " [{'role': 'system', 'content': 'You are a joke telling machine.'},\n",
+       "  {'role': 'user', 'content': 'Tell me something about apples.'}],\n",
+       " [{'role': 'system', 'content': 'You are a joke telling machine.'},\n",
+       "  {'role': 'user', 'content': 'Tell me something about apples.'}],\n",
+       " [{'role': 'system', 'content': 'You are a joke telling machine.'},\n",
+       "  {'role': 'user', 'content': 'Tell me something about apples.'}],\n",
+       " [{'role': 'system', 'content': 'You are a joke telling machine.'},\n",
+       "  {'role': 'user', 'content': 'Tell me something about apples.'}]]"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Duplicate Messages x 5 times so that we can make 5 API calls\n",
     "messages_list = [messages] * 5\n",
@@ -237,9 +580,215 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e2511123356b4e30a9303e4e8624e0da",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Output()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
+      ],
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>system_message</th>\n",
+       "      <th>user_message</th>\n",
+       "      <th>metadata</th>\n",
+       "      <th>response_message</th>\n",
+       "      <th>created_time</th>\n",
+       "      <th>model</th>\n",
+       "      <th>total_tokens</th>\n",
+       "      <th>prompt_tokens</th>\n",
+       "      <th>completion_tokens</th>\n",
+       "      <th>seed</th>\n",
+       "      <th>temperature</th>\n",
+       "      <th>top_p</th>\n",
+       "      <th>max_tokens</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>chatcmpl-8LIL3Z0WuNEHO6x6A3vjEU5qHYEya</td>\n",
+       "      <td>You are a joke telling machine.</td>\n",
+       "      <td>Tell me something about apples.</td>\n",
+       "      <td>None</td>\n",
+       "      <td>Sure! Did you hear about the apple that joined...</td>\n",
+       "      <td>1700086073</td>\n",
+       "      <td>gpt-3.5-turbo-1106</td>\n",
+       "      <td>47</td>\n",
+       "      <td>24</td>\n",
+       "      <td>23</td>\n",
+       "      <td>None</td>\n",
+       "      <td>0.9</td>\n",
+       "      <td>0.9</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>chatcmpl-8LIL3kuZ296LHjrzvV2k250r1VjkX</td>\n",
+       "      <td>You are a joke telling machine.</td>\n",
+       "      <td>Tell me something about apples.</td>\n",
+       "      <td>None</td>\n",
+       "      <td>Sure! Did you hear about the apple that went o...</td>\n",
+       "      <td>1700086073</td>\n",
+       "      <td>gpt-3.5-turbo-1106</td>\n",
+       "      <td>48</td>\n",
+       "      <td>24</td>\n",
+       "      <td>24</td>\n",
+       "      <td>None</td>\n",
+       "      <td>0.9</td>\n",
+       "      <td>0.9</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>chatcmpl-8LIL4ERAgZT72ybOqtqsyqSr1DC6s</td>\n",
+       "      <td>You are a joke telling machine.</td>\n",
+       "      <td>Tell me something about apples.</td>\n",
+       "      <td>None</td>\n",
+       "      <td>Sure! Did you hear about the apple who went to...</td>\n",
+       "      <td>1700086074</td>\n",
+       "      <td>gpt-3.5-turbo-1106</td>\n",
+       "      <td>68</td>\n",
+       "      <td>24</td>\n",
+       "      <td>44</td>\n",
+       "      <td>None</td>\n",
+       "      <td>0.9</td>\n",
+       "      <td>0.9</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>chatcmpl-8LIL4q1BuM549bQSQ1hxc3p0kPXVE</td>\n",
+       "      <td>You are a joke telling machine.</td>\n",
+       "      <td>Tell me something about apples.</td>\n",
+       "      <td>None</td>\n",
+       "      <td>Why did the apple go to the doctor? Because it...</td>\n",
+       "      <td>1700086074</td>\n",
+       "      <td>gpt-3.5-turbo-1106</td>\n",
+       "      <td>41</td>\n",
+       "      <td>24</td>\n",
+       "      <td>17</td>\n",
+       "      <td>None</td>\n",
+       "      <td>0.9</td>\n",
+       "      <td>0.9</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>chatcmpl-8LIL48ILhKaXSpRBpM94aav2uC551</td>\n",
+       "      <td>You are a joke telling machine.</td>\n",
+       "      <td>Tell me something about apples.</td>\n",
+       "      <td>None</td>\n",
+       "      <td>Sure! Did you hear about the apple that went o...</td>\n",
+       "      <td>1700086074</td>\n",
+       "      <td>gpt-3.5-turbo-1106</td>\n",
+       "      <td>53</td>\n",
+       "      <td>24</td>\n",
+       "      <td>29</td>\n",
+       "      <td>None</td>\n",
+       "      <td>0.9</td>\n",
+       "      <td>0.9</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                       id                   system_message  \\\n",
+       "0  chatcmpl-8LIL3Z0WuNEHO6x6A3vjEU5qHYEya  You are a joke telling machine.   \n",
+       "1  chatcmpl-8LIL3kuZ296LHjrzvV2k250r1VjkX  You are a joke telling machine.   \n",
+       "2  chatcmpl-8LIL4ERAgZT72ybOqtqsyqSr1DC6s  You are a joke telling machine.   \n",
+       "3  chatcmpl-8LIL4q1BuM549bQSQ1hxc3p0kPXVE  You are a joke telling machine.   \n",
+       "4  chatcmpl-8LIL48ILhKaXSpRBpM94aav2uC551  You are a joke telling machine.   \n",
+       "\n",
+       "                      user_message metadata  \\\n",
+       "0  Tell me something about apples.     None   \n",
+       "1  Tell me something about apples.     None   \n",
+       "2  Tell me something about apples.     None   \n",
+       "3  Tell me something about apples.     None   \n",
+       "4  Tell me something about apples.     None   \n",
+       "\n",
+       "                                    response_message  created_time  \\\n",
+       "0  Sure! Did you hear about the apple that joined...    1700086073   \n",
+       "1  Sure! Did you hear about the apple that went o...    1700086073   \n",
+       "2  Sure! Did you hear about the apple who went to...    1700086074   \n",
+       "3  Why did the apple go to the doctor? Because it...    1700086074   \n",
+       "4  Sure! Did you hear about the apple that went o...    1700086074   \n",
+       "\n",
+       "                model  total_tokens  prompt_tokens  completion_tokens  seed  \\\n",
+       "0  gpt-3.5-turbo-1106            47             24                 23  None   \n",
+       "1  gpt-3.5-turbo-1106            48             24                 24  None   \n",
+       "2  gpt-3.5-turbo-1106            68             24                 44  None   \n",
+       "3  gpt-3.5-turbo-1106            41             24                 17  None   \n",
+       "4  gpt-3.5-turbo-1106            53             24                 29  None   \n",
+       "\n",
+       "   temperature  top_p max_tokens  \n",
+       "0          0.9    0.9       None  \n",
+       "1          0.9    0.9       None  \n",
+       "2          0.9    0.9       None  \n",
+       "3          0.9    0.9       None  \n",
+       "4          0.9    0.9       None  "
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Use Async Chat Completions, limit to 2 concurrent API calls at any given time\n",
     "responses_list = await model.async_chat_completions(  # noqa: F704\n",
@@ -273,9 +822,43 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "In Callback. Messages: Message(messages=[{'role': 'system', 'content': 'You are a joke telling machine.'}, {'role': 'user', 'content': 'Tell me something about apples.'}], metadata={'a': 1})\n",
+      "In Callback. Response: {'id': 'chatcmpl-8LILBkfH7yk4FZO1Q8EStTOU2xQMI', 'system_message': 'You are a joke telling machine.', 'user_message': 'Tell me something about apples.', 'metadata': {'a': 1}, 'response_message': 'Why did the apple go to school?\\n\\nBecause it wanted to be a \"smart\" apple!', 'created_time': 1700086081, 'model': 'gpt-3.5-turbo-1106', 'total_tokens': 43, 'prompt_tokens': 24, 'completion_tokens': 19, 'seed': None, 'temperature': 0.9, 'top_p': 0.9, 'max_tokens': None}\n",
+      "\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'id': 'chatcmpl-8LILBkfH7yk4FZO1Q8EStTOU2xQMI',\n",
+       " 'system_message': 'You are a joke telling machine.',\n",
+       " 'user_message': 'Tell me something about apples.',\n",
+       " 'metadata': {'a': 1},\n",
+       " 'response_message': 'Why did the apple go to school?\\n\\nBecause it wanted to be a \"smart\" apple!',\n",
+       " 'created_time': 1700086081,\n",
+       " 'model': 'gpt-3.5-turbo-1106',\n",
+       " 'total_tokens': 43,\n",
+       " 'prompt_tokens': 24,\n",
+       " 'completion_tokens': 19,\n",
+       " 'seed': None,\n",
+       " 'temperature': 0.9,\n",
+       " 'top_p': 0.9,\n",
+       " 'max_tokens': None}"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "system_message = \"You are a joke telling machine.\"\n",
     "user_message = \"Tell me something about apples.\"\n",
@@ -318,9 +901,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[Message(messages=[{'role': 'system', 'content': 'You are a joke telling machine.'}, {'role': 'user', 'content': 'Tell me something about apples.'}], metadata={'a': 1}),\n",
+       " Message(messages=[{'role': 'system', 'content': 'You are a joke telling machine.'}, {'role': 'user', 'content': 'Tell me something about apples.'}], metadata={'a': 1}),\n",
+       " Message(messages=[{'role': 'system', 'content': 'You are a joke telling machine.'}, {'role': 'user', 'content': 'Tell me something about apples.'}], metadata={'b': 2})]"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Multiple concurrent async chat completions using Message\n",
     "# NOTE: we make the 3rd Message with different metadata.  This should cause\n",
@@ -332,9 +928,233 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ebc9ac47809d4fff8acc9db24a0e3650",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Output()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">In Callback. Messages: Message(messages=[{'role': 'system', 'content': 'You are a joke telling machine.'}, {'role':\n",
+       "'user', 'content': 'Tell me something about apples.'}], metadata={'a': 1})\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "In Callback. Messages: Message(messages=[{'role': 'system', 'content': 'You are a joke telling machine.'}, {'role':\n",
+       "'user', 'content': 'Tell me something about apples.'}], metadata={'a': 1})\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">In Callback. Response: {'id': 'chatcmpl-8LILIcDJyzGrKomK2TVnDzWwooqkX', 'system_message': 'You are a joke telling \n",
+       "machine.', 'user_message': 'Tell me something about apples.', 'metadata': {'a': 1}, 'response_message': 'Why did \n",
+       "the apple go to therapy?\\n\\nBecause it had too many core issues!', 'created_time': 1700086088, 'model': \n",
+       "'gpt-3.5-turbo-1106', 'total_tokens': 40, 'prompt_tokens': 24, 'completion_tokens': 16, 'seed': None, \n",
+       "'temperature': 0.9, 'top_p': 0.9, 'max_tokens': None}\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "In Callback. Response: {'id': 'chatcmpl-8LILIcDJyzGrKomK2TVnDzWwooqkX', 'system_message': 'You are a joke telling \n",
+       "machine.', 'user_message': 'Tell me something about apples.', 'metadata': {'a': 1}, 'response_message': 'Why did \n",
+       "the apple go to therapy?\\n\\nBecause it had too many core issues!', 'created_time': 1700086088, 'model': \n",
+       "'gpt-3.5-turbo-1106', 'total_tokens': 40, 'prompt_tokens': 24, 'completion_tokens': 16, 'seed': None, \n",
+       "'temperature': 0.9, 'top_p': 0.9, 'max_tokens': None}\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">In Callback. Messages: Message(messages=[{'role': 'system', 'content': 'You are a joke telling machine.'}, {'role':\n",
+       "'user', 'content': 'Tell me something about apples.'}], metadata={'a': 1})\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "In Callback. Messages: Message(messages=[{'role': 'system', 'content': 'You are a joke telling machine.'}, {'role':\n",
+       "'user', 'content': 'Tell me something about apples.'}], metadata={'a': 1})\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">In Callback. Response: {'id': 'chatcmpl-8LILIcbSRuWmhzdoe9PSICAtjv80c', 'system_message': 'You are a joke telling \n",
+       "machine.', 'user_message': 'Tell me something about apples.', 'metadata': {'a': 1}, 'response_message': \"Why did \n",
+       "the apple break up with the orange? Because it couldn't handle the pithy comments!\", 'created_time': 1700086088, \n",
+       "'model': 'gpt-3.5-turbo-1106', 'total_tokens': 45, 'prompt_tokens': 24, 'completion_tokens': 21, 'seed': None, \n",
+       "'temperature': 0.9, 'top_p': 0.9, 'max_tokens': None}\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "In Callback. Response: {'id': 'chatcmpl-8LILIcbSRuWmhzdoe9PSICAtjv80c', 'system_message': 'You are a joke telling \n",
+       "machine.', 'user_message': 'Tell me something about apples.', 'metadata': {'a': 1}, 'response_message': \"Why did \n",
+       "the apple break up with the orange? Because it couldn't handle the pithy comments!\", 'created_time': 1700086088, \n",
+       "'model': 'gpt-3.5-turbo-1106', 'total_tokens': 45, 'prompt_tokens': 24, 'completion_tokens': 21, 'seed': None, \n",
+       "'temperature': 0.9, 'top_p': 0.9, 'max_tokens': None}\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">In Callback. Messages: Message(messages=[{'role': 'system', 'content': 'You are a joke telling machine.'}, {'role':\n",
+       "'user', 'content': 'Tell me something about apples.'}], metadata={'b': 2})\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "In Callback. Messages: Message(messages=[{'role': 'system', 'content': 'You are a joke telling machine.'}, {'role':\n",
+       "'user', 'content': 'Tell me something about apples.'}], metadata={'b': 2})\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">In Callback. Response: {'id': 'chatcmpl-8LILI6BdPHkmvkyH6cGSJM1X8YkrW', 'system_message': 'You are a joke telling \n",
+       "machine.', 'user_message': 'Tell me something about apples.', 'metadata': {'b': 2}, 'response_message': \"Why did \n",
+       "the apple go to the doctor? Because it wasn't peeling well!\", 'created_time': 1700086088, 'model': \n",
+       "'gpt-3.5-turbo-1106', 'total_tokens': 41, 'prompt_tokens': 24, 'completion_tokens': 17, 'seed': None, \n",
+       "'temperature': 0.9, 'top_p': 0.9, 'max_tokens': None}\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "In Callback. Response: {'id': 'chatcmpl-8LILI6BdPHkmvkyH6cGSJM1X8YkrW', 'system_message': 'You are a joke telling \n",
+       "machine.', 'user_message': 'Tell me something about apples.', 'metadata': {'b': 2}, 'response_message': \"Why did \n",
+       "the apple go to the doctor? Because it wasn't peeling well!\", 'created_time': 1700086088, 'model': \n",
+       "'gpt-3.5-turbo-1106', 'total_tokens': 41, 'prompt_tokens': 24, 'completion_tokens': 17, 'seed': None, \n",
+       "'temperature': 0.9, 'top_p': 0.9, 'max_tokens': None}\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
+      ],
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# Use Async Chat Completions, limit to 2 concurrent API calls at any given time & 1 retry\n",
     "responses_list = await model.async_chat_completions(  # noqa: F704\n",
@@ -348,9 +1168,48 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[{'id': 'chatcmpl-8LILIcbSRuWmhzdoe9PSICAtjv80c',\n",
+       "  'system_message': 'You are a joke telling machine.',\n",
+       "  'user_message': 'Tell me something about apples.',\n",
+       "  'metadata': {'a': 1},\n",
+       "  'response_message': \"Why did the apple break up with the orange? Because it couldn't handle the pithy comments!\",\n",
+       "  'created_time': 1700086088,\n",
+       "  'model': 'gpt-3.5-turbo-1106',\n",
+       "  'total_tokens': 45,\n",
+       "  'prompt_tokens': 24,\n",
+       "  'completion_tokens': 21,\n",
+       "  'seed': None,\n",
+       "  'temperature': 0.9,\n",
+       "  'top_p': 0.9,\n",
+       "  'max_tokens': None},\n",
+       " {'id': 'chatcmpl-8LILIcDJyzGrKomK2TVnDzWwooqkX',\n",
+       "  'system_message': 'You are a joke telling machine.',\n",
+       "  'user_message': 'Tell me something about apples.',\n",
+       "  'metadata': {'a': 1},\n",
+       "  'response_message': 'Why did the apple go to therapy?\\n\\nBecause it had too many core issues!',\n",
+       "  'created_time': 1700086088,\n",
+       "  'model': 'gpt-3.5-turbo-1106',\n",
+       "  'total_tokens': 40,\n",
+       "  'prompt_tokens': 24,\n",
+       "  'completion_tokens': 16,\n",
+       "  'seed': None,\n",
+       "  'temperature': 0.9,\n",
+       "  'top_p': 0.9,\n",
+       "  'max_tokens': None},\n",
+       " None]"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Examine responses.\n",
     "# - We should get valid responses for the first 2 responses.\n",
@@ -368,7 +1227,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -386,9 +1245,86 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "cbc97460112941dab45a8111848605a9",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Output()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">/Users/philipchung/Developer/automated-llm-eval/automated_llm_eval/chat_model.py:328: UserWarning: Failed to create\n",
+       "ChatCompletion with arguments: dict_items([('messages', Message(messages=[{'role': 'system', 'content': 'You are a \n",
+       "joke telling machine.'}, {'role': 'user', 'content': 'Tell me something about apples.'}], metadata={'a': 1})), \n",
+       "('model', 'gpt-3.5-turbo-1106'), ('temperature', 0.9), ('top_p', 0.9), ('max_tokens', None), ('n', 1), ('seed', \n",
+       "None)])\n",
+       "Exception: \n",
+       "Retries left: 5\n",
+       "  warnings.warn(\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "/Users/philipchung/Developer/automated-llm-eval/automated_llm_eval/chat_model.py:328: UserWarning: Failed to create\n",
+       "ChatCompletion with arguments: dict_items([('messages', Message(messages=[{'role': 'system', 'content': 'You are a \n",
+       "joke telling machine.'}, {'role': 'user', 'content': 'Tell me something about apples.'}], metadata={'a': 1})), \n",
+       "('model', 'gpt-3.5-turbo-1106'), ('temperature', 0.9), ('top_p', 0.9), ('max_tokens', None), ('n', 1), ('seed', \n",
+       "None)])\n",
+       "Exception: \n",
+       "Retries left: 5\n",
+       "  warnings.warn(\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
+      ],
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[Bundle(id='chatcmpl-8LILXRTjxlnIu0lk6yvEvZZHNGynL', system_message='You are a joke telling machine.', user_message='Tell me something about apples.', metadata={'a': 1}, response_message='Why did the apple go to school?\\n\\nBecause it wanted to be a \"smart\" apple!', created_time=1700086103, model='gpt-3.5-turbo-1106', total_tokens=43, prompt_tokens=24, completion_tokens=19, seed=None, temperature=0.9, top_p=0.9, max_tokens=None),\n",
+       " Bundle(id='chatcmpl-8LILSe9zlppqjSFLLppyJKvx9PK4q', system_message='You are a joke telling machine.', user_message='Tell me something about apples.', metadata={'a': 1}, response_message=\"Sure! Did you hear about the apple who went to a party? He was the apple of everyone's eye!\", created_time=1700086098, model='gpt-3.5-turbo-1106', total_tokens=47, prompt_tokens=24, completion_tokens=23, seed=None, temperature=0.9, top_p=0.9, max_tokens=None),\n",
+       " Bundle(id='chatcmpl-8LILTqQPgygaqYYw4qKBFzwIQNERc', system_message='You are a joke telling machine.', user_message='Tell me something about apples.', metadata={'a': 1}, response_message='Why did the apple go to school? Because it wanted to be a \"smart\" apple!', created_time=1700086099, model='gpt-3.5-turbo-1106', total_tokens=43, prompt_tokens=24, completion_tokens=19, seed=None, temperature=0.9, top_p=0.9, max_tokens=None)]"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Up until now, we have used `await` to call async functions and wait for their completion.\n",
     "# However, `await` this can only be used within async functions.\n",
@@ -401,9 +1337,59 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "78d1827308174e9ca73b9cdac88a256d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Output()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
+      ],
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[Bundle(id='chatcmpl-8LILaCN5zBKFT2f1NVO8KVfdWOHKF', system_message='You are a joke telling machine.', user_message='Tell me something about apples.', metadata={'a': 1}, response_message='Sure! Did you hear about the apple who went to school? He wanted to be a \"smart\" apple!', created_time=1700086106, model='gpt-3.5-turbo-1106', total_tokens=47, prompt_tokens=24, completion_tokens=23, seed=None, temperature=0.9, top_p=0.9, max_tokens=None),\n",
+       " Bundle(id='chatcmpl-8LILZ5oC2cegD0t6n7tAGYDB8dgwI', system_message='You are a joke telling machine.', user_message='Tell me something about apples.', metadata={'a': 1}, response_message=\"Why did the apple go to the doctor? Because it wasn't peeling well!\", created_time=1700086105, model='gpt-3.5-turbo-1106', total_tokens=41, prompt_tokens=24, completion_tokens=17, seed=None, temperature=0.9, top_p=0.9, max_tokens=None),\n",
+       " Bundle(id='chatcmpl-8LILZXMugSlaP2R2JGWiWF0tKmK4J', system_message='You are a joke telling machine.', user_message='Tell me something about apples.', metadata={'a': 1}, response_message=\"Why did the apple break up with the orange? Because it couldn't find the core of the relationship!\", created_time=1700086105, model='gpt-3.5-turbo-1106', total_tokens=45, prompt_tokens=24, completion_tokens=21, seed=None, temperature=0.9, top_p=0.9, max_tokens=None)]"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# We have created a helper function to address this issue.\n",
     "#\n",

--- a/notebooks/dev_notebook.py
+++ b/notebooks/dev_notebook.py
@@ -186,7 +186,7 @@ model = ChatModel(model="gpt-3.5-turbo-1106")
 # - allow up to 1 retry.  If still fails/rejected after 1 retry, then will return `None`.
 response = model.chat_completion(
     m,
-    output_format="simple",
+    output_format="bundle_dict",
     validation_callback=validation_callback_fn,
     num_retries=1,
 )
@@ -206,7 +206,7 @@ responses_list = await model.async_chat_completions(  # noqa: F704
     num_concurrent=2,
     num_retries=1,
     validation_callback=validation_callback_fn,
-    output_format="simple",
+    output_format="bundle_dict",
 )
 # %%
 # Examine responses.


### PR DESCRIPTION
This adds:
1. `Message.metadata` in `Message` is now passed into output results from LLM generation if we select `output_format="bundle"` or `output_format="bundle_dict"`.  Also note that `ChatModel.async_chat_completions()` should return the outputs in the same order as input Messages in `messages_list`.
2. Concurrent generation of a batch from the dataset in `policy_tuning`.  This illustrates how to use the concurrent generation in the existing workflow.
3. Reformatting package imports and other code so my type checker/code formatters complain less. 